### PR TITLE
Upgrade to .NET 10.0 and Visual Studio 2022 (v18)

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -17,10 +17,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      # - name: Setup .NET
-      #   uses: actions/setup-dotnet@v4
-      #   with:
-      #     dotnet-version: 9.x
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.x
       - name: Restore dependencies
         run: dotnet restore
       - name: Build

--- a/AdventOfCode.sln
+++ b/AdventOfCode.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.2.32616.157
+# Visual Studio Version 18
+VisualStudioVersion = 18.0.11018.127 d18.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AdventOfCode", "source\AdventOfCode\AdventOfCode.csproj", "{5D8AC52A-BB51-4350-A2F0-B1B2041076E0}"
 EndProject
@@ -22,7 +22,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
 		Directory.Packages.props = Directory.Packages.props
+		global.json = global.json
 		NuGet.Config = NuGet.Config
+		version.json = version.json
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AdventOfCode.Shared.Tests", "tests\AdventOfCode.Shared.Tests\AdventOfCode.Shared.Tests.csproj", "{53FC9206-FA5A-4B4C-8E81-0CE9FE021B8E}"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <Product>AdventOfCode</Product>
     <Authors>Rory Claasen</Authors>
 
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <Nullable>enable</Nullable>
     <IsPublishable>false</IsPublishable>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "10.0",
+    "rollForward": "latestFeature"
+  }
+}


### PR DESCRIPTION
## 📑 Description
Updated the solution to use .NET 10.0 and Visual Studio 2022.
- Updated `AdventOfCode.sln` to reflect Visual Studio v18.
- Added `global.json` to specify .NET SDK version 10.0.
- Updated target framework in `Directory.Build.props` to `net10.0`.
- Added `version.json` to "Solution Items" for version management.

## ✅ Checks
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
