### PR TITLE
Small tweaks based off warnings

### DIFF
--- a/source/AdventOfCode.Shared/Extensions/IIEnumerableExtensions.cs
+++ b/source/AdventOfCode.Shared/Extensions/IIEnumerableExtensions.cs
@@ -6,22 +6,16 @@ using System.Numerics;
 
 public static partial class IIEnumerableExtensions
 {
-    public static int Product(this IEnumerable<int> x) => Product<int, int>(x);
+    public static TNumber Product<TNumber>(this IEnumerable<TNumber> source)
+        where TNumber : struct, INumber<TNumber>
+        => Product<TNumber, TNumber>(source);
 
-    public static long Product(this IEnumerable<long> x) => Product<long, long>(x);
-
-    public static float Product(this IEnumerable<float> x) => Product<float, float>(x);
-
-    public static double Product(this IEnumerable<double> x) => Product<double, double>(x);
-
-    public static decimal Product(this IEnumerable<decimal> x) => Product<decimal, decimal>(x);
-
-    private static TResult Product<TSource, TResult>(this IEnumerable<TSource> x)
+    public static TResult Product<TSource, TResult>(this IEnumerable<TSource> source)
         where TSource : struct, INumber<TSource>
         where TResult : struct, INumber<TResult>
     {
         TResult result = TResult.One;
-        foreach (var item in x)
+        foreach (var item in source)
         {
             checked
             {

--- a/source/AdventOfCode.Shared/Extensions/MatrixExtensions.cs
+++ b/source/AdventOfCode.Shared/Extensions/MatrixExtensions.cs
@@ -64,18 +64,14 @@ public static class MatrixExtensions
     {
         ArgumentNullException.ThrowIfNull(source, nameof(source));
 
-        return Enumerable.Range(0, source.GetLength(1))
-            .Select(x => source[rowIndex, x])
-            .ToArray();
+        return [.. Enumerable.Range(0, source.GetLength(1)).Select(x => source[rowIndex, x])];
     }
 
     public static T[] GetColumn<T>(this T[,] source, int columnIndex)
     {
         ArgumentNullException.ThrowIfNull(source, nameof(source));
 
-        return Enumerable.Range(0, source.GetLength(0))
-            .Select(x => source[x, columnIndex])
-            .ToArray();
+        return [.. Enumerable.Range(0, source.GetLength(0)).Select(x => source[x, columnIndex])];
     }
 
     public static T[,] Rotate<T>(this T[,] source, bool clockwise = true)

--- a/source/AdventOfCode.Year2015/Day15/Day15Solution.cs
+++ b/source/AdventOfCode.Year2015/Day15/Day15Solution.cs
@@ -15,13 +15,13 @@ public partial class Day15Solution : IProblemSolver
     public object? PartOne(string input)
     {
         var ingredients = ParseInput(input);
-        return GetBestScore(ingredients.ToArray(), (capacity, durability, flavor, texture, _) => capacity * durability * flavor * texture);
+        return GetBestScore([.. ingredients], (capacity, durability, flavor, texture, _) => capacity * durability * flavor * texture);
     }
 
     public object? PartTwo(string input)
     {
         var ingredients = ParseInput(input);
-        return GetBestScore(ingredients.ToArray(), (capacity, durability, flavor, texture, calories) => calories == 500 ? capacity * durability * flavor * texture : 0);
+        return GetBestScore([.. ingredients], (capacity, durability, flavor, texture, calories) => calories == 500 ? capacity * durability * flavor * texture : 0);
     }
 
     private static int GetBestScore(Ingredient[] ingredients, Func<int, int, int, int, int, int> bestScore)

--- a/source/AdventOfCode.Year2015/Day22/Day22Solution.cs
+++ b/source/AdventOfCode.Year2015/Day22/Day22Solution.cs
@@ -36,7 +36,7 @@ public partial class Day22Solution : IProblemSolver
                 }
             }
 
-            currentFights = GetNextFights(currentFights.Where(IsGameRunning)).ToList();
+            currentFights = [.. GetNextFights(currentFights.Where(IsGameRunning))];
 
             foreach (var fight in currentFights.Where(IsGameRunning))
             {
@@ -95,7 +95,7 @@ public partial class Day22Solution : IProblemSolver
                 }
             }
 
-            currentFights = GetNextFights(currentFights.Where(IsGameRunning)).ToList();
+            currentFights = [.. GetNextFights(currentFights.Where(IsGameRunning))];
 
             foreach (var fight in currentFights.Where(IsGameRunning))
             {

--- a/source/AdventOfCode.Year2015/Day7/Day7Solution.cs
+++ b/source/AdventOfCode.Year2015/Day7/Day7Solution.cs
@@ -31,7 +31,7 @@ public partial class Day7Solution : IProblemSolver
     public Dictionary<string, ushort> RunInput(string input)
     {
         var instructions = this.ParseInput(input);
-        return RunInstructions(instructions.ToList());
+        return RunInstructions([.. instructions]);
     }
 
     private static Dictionary<string, ushort> RunInstructions(List<InstructionBase> instructions)

--- a/source/AdventOfCode.Year2016/Day4/Day4Solution.cs
+++ b/source/AdventOfCode.Year2016/Day4/Day4Solution.cs
@@ -30,7 +30,7 @@ public partial class Day4Solution : IProblemSolver
     private bool IsRealRoom(Room room)
     {
         var letterCounts = room.Name.Where(c => c != '-').GroupBy(c => c).Select(g => (g.Key, g.Count())).OrderByDescending(g => g.Item2).ThenBy(g => g.Key).Take(5).ToArray();
-        var checksum = new string(letterCounts.Select(g => g.Key).ToArray());
+        var checksum = new string([.. letterCounts.Select(g => g.Key)]);
         return checksum == room.Checksum;
     }
 

--- a/source/AdventOfCode.Year2019/Day3/Day3Solution.cs
+++ b/source/AdventOfCode.Year2019/Day3/Day3Solution.cs
@@ -62,7 +62,7 @@ public partial class Day3Solution : IProblemSolver
             .Split(',')
             .Select(ins => new Instruction((Direction)ins[0], int.Parse(ins[1..])));
 
-        return input.Lines().Select(ParseLine).ToArray();
+        return [.. input.Lines().Select(ParseLine)];
     }
 
     record Instruction(Direction Direction, int Distance);

--- a/source/AdventOfCode.Year2020/Day1/Day1Solution.cs
+++ b/source/AdventOfCode.Year2020/Day1/Day1Solution.cs
@@ -13,13 +13,13 @@ public partial class Day1Solution : IProblemSolver
     public object? PartOne(string input)
     {
         var entries = ParseInput(input);
-        return ProductEntriesThatSum(Target, 2, entries.ToArray());
+        return ProductEntriesThatSum(Target, 2, [.. entries]);
     }
 
     public object? PartTwo(string input)
     {
         var entries = ParseInput(input);
-        return ProductEntriesThatSum(Target, 3, entries.ToArray());
+        return ProductEntriesThatSum(Target, 3, [.. entries]);
     }
 
     private static IEnumerable<int> ParseInput(string input)

--- a/source/AdventOfCode.Year2022/Day5/Day5Solution.cs
+++ b/source/AdventOfCode.Year2022/Day5/Day5Solution.cs
@@ -49,7 +49,7 @@ public partial class Day5Solution : IProblemSolver
     private static IputData ParseInput(string input)
     {
         var data = input.Lines(2);
-        return new IputData(ParseStack(data[0]).ToArray(), PasrseInstruction(data[1]));
+        return new IputData([.. ParseStack(data[0])], PasrseInstruction(data[1]));
     }
 
     private static IEnumerable<Stack<char>> ParseStack(string input)

--- a/source/AdventOfCode.Year2023/Day7/Day7Solution.cs
+++ b/source/AdventOfCode.Year2023/Day7/Day7Solution.cs
@@ -83,7 +83,7 @@ public partial class Day7Solution : IProblemSolver
             }
 
             static char[] ReplaceJoker(char newCard, char[] cards)
-                => cards.Select(c => c == 'J' ? newCard : c).ToArray();
+                => [.. cards.Select(c => c == 'J' ? newCard : c)];
 
             return this.CamelCards
                 .Where(c => c != 'J')

--- a/source/AdventOfCode.Year2024/Day5/Day5Solution.cs
+++ b/source/AdventOfCode.Year2024/Day5/Day5Solution.cs
@@ -32,7 +32,7 @@ public partial class Day5Solution : IProblemSolver
             {
                 if (!this.SearchCache.TryGetValue(page, out var rules))
                 {
-                    rules = input.Rules.Where(r => r.After == page).ToArray();
+                    rules = [.. input.Rules.Where(r => r.After == page)];
                     this.SearchCache[page] = rules;
                 }
 
@@ -56,7 +56,7 @@ public partial class Day5Solution : IProblemSolver
             {
                 if (!this.SearchCache.TryGetValue(page, out var rules))
                 {
-                    rules = input.Rules.Where(r => r.After == page).ToArray();
+                    rules = [.. input.Rules.Where(r => r.After == page)];
                     this.SearchCache[page] = rules;
                 }
 

--- a/tests/AdventOfCode.Shared.Tests/AdventUriTests.cs
+++ b/tests/AdventOfCode.Shared.Tests/AdventUriTests.cs
@@ -31,7 +31,7 @@ public class AdventUriTests
     [DataRow(2021)]
     public void BuildUriForYearThrowsWhenYearsOutOfRange(int year)
     {
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => this.adventUri.Build(year));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => this.adventUri.Build(year));
     }
 
     [TestMethod]
@@ -47,7 +47,7 @@ public class AdventUriTests
     [DataRow(2021)]
     public void BuildUriUriForDayThrowsWhenYearIsOutOfRange(int year)
     {
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => this.adventUri.Build(year, 1));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => this.adventUri.Build(year, 1));
     }
 
     [TestMethod]
@@ -55,6 +55,6 @@ public class AdventUriTests
     [DataRow(26)]
     public void BuildUriUriForDayThrowsWhenDayIsOutOfRange(int day)
     {
-        Assert.ThrowsException<ArgumentOutOfRangeException>(() => this.adventUri.Build(2020, day));
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => this.adventUri.Build(2020, day));
     }
 }


### PR DESCRIPTION
## 📑 Description
Replaced Assert.ThrowsException<TException> with
Assert.ThrowsExactly<TException> in multiple test methods
in AdventUriTests.cs. This ensures that the tests validate
only the exact exception type ArgumentOutOfRangeException,
improving the precision of exception handling assertions.

Updated test methods:
- BuildUriForYearThrowsWhenYearsOutOfRange
- BuildUriUriForDayThrowsWhenYearIsOutOfRange
- BuildUriUriForDayThrowsWhenDayIsOutOfRange

Replaced type-specific Product overloads with a generic implementation using the INumber<T> interface, simplifying the code and supporting all numeric types. Updated Product<TSource, TResult> to use consistent parameter naming and made it public. Added System.Collections.Generic namespace for IEnumerable<T>. Retained overflow checking with the checked block.

Replaced `ToArray()` and `ToList()` calls with the new C# collection expression syntax `[..]` across multiple files. This change simplifies array and collection creation from enumerable sequences, improving code readability and conciseness.

- Updated `GetRow` and `GetColumn` in `MatrixExtensions.cs` to use `[..]`.
- Refactored `PartOne` and `PartTwo` in `Day15Solution.cs` to use `[..]`.
- Simplified `currentFights` handling in `Day22Solution.cs` with `[..]`.
- Updated `RunInput` in `Day7Solution.cs` to use `[..]`.
- Refactored `IsRealRoom` in `Day4Solution.cs` to use `[..]`.
- Simplified `ParseLine` in `Day3Solution.cs` with `[..]`.
- Updated `PartOne` and `PartTwo` in `Day1Solution.cs` to use `[..]`.
- Refactored `ParseInput` and other methods in `Day5Solution.cs` to use `[..]`.

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed
